### PR TITLE
add parser method that get struct name of payloadtype

### DIFF
--- a/pkg/gen/fixtures/task.go
+++ b/pkg/gen/fixtures/task.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"context"
+	"goq/pkg/pubsub"
+	"goq/pkg/task"
+	"log"
+
+	"github.com/google/uuid"
+)
+
+type Greeter struct {
+	task.BaseTasker
+	Config task.Config
+}
+
+// Handle handles the message
+func (g *Greeter) Handle(ctx context.Context, msg pubsub.Message) error {
+	log.Println("greet: ", msg)
+	return nil
+}
+
+func (g *Greeter) Async(ctx context.Context, text string) error {
+	msg := pubsub.Message{
+		Payload:  text,
+		TaskName: task.GetTaskName(g),
+		UUID:     uuid.New().String(),
+	}
+
+	return g.Delay(ctx, msg)
+}
+
+func (g *Greeter) Delay(ctx context.Context, msg pubsub.Message) error {
+	return g.GetPubsuber().Publish(ctx, task.GetTaskName(g), msg)
+}
+
+func NewGreeter(name string, queue string) *Greeter {
+	return &Greeter{
+		Config: task.Config{
+			Name:  name,
+			Queue: queue,
+		},
+	}
+}

--- a/pkg/gen/parser.go
+++ b/pkg/gen/parser.go
@@ -1,0 +1,86 @@
+package gen
+
+import (
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"log"
+	"os"
+	"path/filepath"
+)
+
+type TaskMetadata struct {
+	Name        string
+	PayloadType string
+}
+
+const asyncMethodName = "Async"
+
+// parseFile parses a go file and returns ???
+func parseFile(fpath string) TaskMetadata {
+	file, err := os.Open(fpath)
+	if err != nil {
+		fmt.Println(os.Getwd())
+		log.Fatal(fmt.Sprintf("cannot open file %s with error %v ", fpath, err))
+	}
+	defer file.Close()
+
+	fset := token.NewFileSet()
+
+	node, err := parser.ParseFile(fset, fpath, file, parser.AllErrors)
+	if err != nil {
+		log.Fatal(fmt.Sprintf("cannot parse file %s with error %v ", fpath, err))
+	}
+
+	var structName string
+	var payloadType string
+	for _, decl := range node.Decls {
+		switch decl := decl.(type) {
+		case *ast.GenDecl:
+			for _, spec := range decl.Specs {
+				if typeSpec, ok := spec.(*ast.TypeSpec); ok {
+					if _, ok := typeSpec.Type.(*ast.StructType); ok {
+						structName = typeSpec.Name.Name
+					}
+				}
+			}
+		case *ast.FuncDecl:
+			if decl.Name.Name == asyncMethodName {
+				params := decl.Type.Params.List
+				if len(params) <= 1 {
+					log.Fatal("Async method must have at least one parameter")
+				}
+				payloadParam := params[1]
+				payloadType = payloadParam.Type.(*ast.Ident).Name
+			}
+		}
+	}
+
+	return TaskMetadata{
+		Name:        structName,
+		PayloadType: payloadType,
+	}
+}
+
+func findFiles(pattern string) []string {
+	matches, err := filepath.Glob(pattern)
+	if err != nil {
+		log.Fatal(err)
+	}
+	return matches
+}
+
+func ParseFiles(pattern string) []TaskMetadata {
+	fnames := findFiles(pattern)
+	fmt.Println("fnames: ", fnames)
+	var taskMetas []TaskMetadata
+	for _, fname := range fnames {
+		taskMeta := parseFile(fname)
+		if taskMeta.Name == "" {
+			log.Fatal("invalid task file:", fname)
+		}
+		taskMetas = append(taskMetas, taskMeta)
+	}
+	return taskMetas
+}

--- a/pkg/gen/parser_test.go
+++ b/pkg/gen/parser_test.go
@@ -1,0 +1,25 @@
+package gen
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseSingleFile(t *testing.T) {
+	fpath := "./fixtures/task.go"
+	t.Run("parse single file", func(t *testing.T) {
+		taskMeta := parseFile(fpath)
+		assert.Equal(t, "Greeter", taskMeta.Name)
+		assert.Equal(t, "string", taskMeta.PayloadType)
+	})
+}
+
+func TestParseFileList(t *testing.T) {
+	t.Run("parse list of file with pattern", func(t *testing.T) {
+		taskMetas := ParseFiles("./**/*task.go")
+		assert.Equal(t, 1, len(taskMetas))
+		assert.Equal(t, "Greeter", taskMetas[0].Name)
+		assert.Equal(t, "string", taskMetas[0].PayloadType)
+	})
+}


### PR DESCRIPTION
- use go/ast to parse task files and get task struct's name and type of the payload
- use text/template to generate Delay (aka send payload to queue) method to reduce boilerplate.